### PR TITLE
Fix: README RTD links & `poetry` extras dependencies setting

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -31,7 +31,7 @@ jobs:
           run: |
             poetry env use python${{ matrix.python-version }}
         - name: Install dependencies
-          run: poetry install
+          run: poetry install --without=dev
         - name: Start PostgreSQL
           run: |
             cp pgmq_postgres.template.env pgmq_postgres.env

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.9","3.10","3.11","3.12"]
 
     name: Test pgmq-sqlalchemy
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+permissions:
+  contents: read
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pgmq-sqlalchemy/
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python - -y
+
+      - name: Update PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Update Poetry configuration
+        run: poetry config virtualenvs.create false
+
+      - name: Install dependencies
+        run: poetry install --sync --no-interaction --without=dev
+
+      - name: Package project
+        run: poetry build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,20 @@ authors = ["jason810496 <810496@email.wlsh.tyc.edu.tw>"]
 license = "MIT"
 readme = "README.md"
 keywords = ["pgmq","PGMQ","sqlalchemy","SQLAlchemy","tembo_pgmq_python"]
+classifiers = [
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+]
 
 [tool.poetry.urls]
 "Homepage" = "https://github.com/jason810496/pgmq-sqlalchemy"


### PR DESCRIPTION
# Fix README RTD links & `poetry` extras dependencies setting

## Description

- Fix README RTD links `pgmq-sqlalchemy-python` -> `pgmq-sqlalchemy`
- Add Postgres drivers extras dependencies for `poetry`

## Status

- [ ] In progress
- [ ] Ready for review
- [x] Done

## Checklist

- [x] Read the [Contributing Guide](CONTRIBUTING.md)
- [x] Passes tests
- [x] Linted ( we use `pre-commit` with `ruff` )
- [x] Updated documentation